### PR TITLE
Update service box gradient

### DIFF
--- a/styles/elements/_services.scss
+++ b/styles/elements/_services.scss
@@ -8,31 +8,31 @@
 	background: $color-dark;
 	padding: 30px;
 	border-radius: 0.5em;
-	&:before {
-		z-index: -1;
-		content: '';
-		visibility: hidden;
-		opacity: 0;
-		position: absolute;
-		top: 0;
-		left: 0;
-		background-color: #ff82f3;
-		background-image: linear-gradient(45deg, #ff82f3 0%, #7b13ff 50%, #400d64 100%);
-		width: 100%;
-		height: 100%;
-		@include transition(linear 0.1s);
-	}
-	&:after {
-		content: '';
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		background-color: #ff82f3;
-		background-image: linear-gradient(45deg, #ff82f3 0%, #7b13ff 50%, #400d64 100%);
-		width: 100%;
-		height: 2px;
-		@include transition(linear 0.1s);
-	}
+        &:before {
+                z-index: -1;
+                content: '';
+                visibility: hidden;
+                opacity: 0;
+                position: absolute;
+                top: 0;
+                left: 0;
+                background-color: #ffb347;
+                background-image: linear-gradient(to right, #ffb347 0%, #f2935c 25%, #a37b73 50%, #6d7a8b 75%, #4e6a7b 100%);
+                width: 100%;
+                height: 100%;
+                @include transition(linear 0.1s);
+        }
+        &:after {
+                content: '';
+                position: absolute;
+                bottom: 0;
+                left: 0;
+                background-color: #ffb347;
+                background-image: linear-gradient(to right, #ffb347 0%, #f2935c 25%, #a37b73 50%, #6d7a8b 75%, #4e6a7b 100%);
+                width: 100%;
+                height: 2px;
+                @include transition(linear 0.1s);
+        }
 	.service-order {
 		* {
 			margin: 0;
@@ -49,12 +49,16 @@
 			color: white;
 		}
 	}
-	&:hover {
-		&:before {
-			visibility: visible;
-			opacity: 0.1;
-		}
-	}
+        &:hover {
+                &:before {
+                        visibility: visible;
+                        opacity: 0.1;
+                }
+        }
+        &.active {
+                background: linear-gradient(to right, #ffb347 0%, #f2935c 25%, #a37b73 50%, #6d7a8b 75%, #4e6a7b 100%);
+                color: white;
+        }
 }
 @include breakpoint-less(md) {
 	.service-box {


### PR DESCRIPTION
## Summary
- restyle service box with new orange-to-blue gradient
- add `.active` class styling for service boxes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686894abc8e0832c96f24b96c327af07