### PR TITLE
Ensure titles display in white

### DIFF
--- a/styles/helpers/_utilities.scss
+++ b/styles/helpers/_utilities.scss
@@ -9,13 +9,13 @@
 .bg-yellow { background: $color-yellow; }
 
 .bg-light-content {
-	color: $color-primary;
-	h1,h2,h3,h4,h5,h6 { color: $color-dark; }
-	a {
-		&:not([class*='button']) {
-			color: black;
-			&:hover, &:focus { color: $color-dark; }
-		}
+        color: $color-primary;
+        h1,h2,h3,h4,h5,h6 { color: $color-white; }
+        a {
+                &:not([class*='button']) {
+                        color: black;
+                        &:hover, &:focus { color: $color-dark; }
+                }
 	}
 }
 .bg-dark-content {


### PR DESCRIPTION
## Summary
- update bg-light-content heading color to white

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c6554a3a0832c97dbb1d34b080a9c